### PR TITLE
Escape output in based on column type

### DIFF
--- a/src/DataTableQuery.php
+++ b/src/DataTableQuery.php
@@ -98,14 +98,14 @@ class DataTableQuery
                         break;
                     
                     default:
-                        $value = $row->{$column->alias};
+                        $value = esc($row->{$column->alias}); // Escape all other data if not used in formatting types
                         break;
                 }
 
                 if($this->columnDefs->returnAsObject)
-                    $data[$column->alias] = esc($value);
+                    $data[$column->alias] = $value;
                 else
-                    $data[] = esc($value);
+                    $data[] = $value;
                 
             }
 


### PR DESCRIPTION
This approach seems much better, this escapes only the columns not being formatted into types. Also more conveniently placed so you can use the route_to function better.