### PR TITLE
Add arguments to function edit

### DIFF
--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -1,5 +1,5 @@
-<?php 
-namespace Hermawan\DataTables;
+<?php
+namespace DataTables;
 
 use \Config\Services;
 
@@ -97,9 +97,9 @@ class DataTable
      * @param String $column
      * @param Closure $callback
      */
-    public function edit($column, $callback)
+    public function edit($column, $callback,$variable = array()) //Add $variable is an array with variables from script
     {
-        $this->columnDefs->edit($column, $callback);
+        $this->columnDefs->edit($column, $callback,$variable); //Add $variable is an array with variables from script
         return $this;
     }
 

--- a/src/DataTableColumnDefs.php
+++ b/src/DataTableColumnDefs.php
@@ -1,5 +1,5 @@
-<?php 
-namespace Hermawan\DataTables;
+<?php
+namespace DataTables;
 
 class DataTableColumnDefs
 {
@@ -67,7 +67,7 @@ class DataTableColumnDefs
         
     }
 
-    public function edit($alias, $callback)
+    public function edit($alias, $callback, $variable = array()) //Add $variable is an array with variables from script
     {
         if($alias)
         {
@@ -76,6 +76,7 @@ class DataTableColumnDefs
             {
                 $column->type     = 'edit';
                 $column->callback = $callback;
+                $column->variable = $variable; // add an array for transmit variable in an array
             }
             
         }

--- a/src/DataTableQuery.php
+++ b/src/DataTableQuery.php
@@ -1,5 +1,5 @@
-<?php 
-namespace Hermawan\DataTables;
+<?php
+namespace DataTables;
 
 
 class DataTableQuery
@@ -91,9 +91,9 @@ class DataTableQuery
                         $value    = $callback($row);
                         break;
                     
-                    case 'edit':
+                    case 'edit': //Add in function call 2 arguments. $column->alias who is the name of the column and $column->variable who is un array with variable from script
                         $callback = $column->callback;
-                        $value    = $callback($row);
+                        $value    = $callback($row,$column->alias,$column->variable);
                         break;
                     
                     case 'format':


### PR DESCRIPTION
Add 1 argument ($variable) in funtion edit and 2 argument in function callback.
It's more usefull to create helper for edit column.

Now function edit is call like this

$datatables->edit(**$column_name**,**function($row,$alias,$array_variables)**,**$variable**);

- First argument is the same.
- The second is the function where you make change (callback)
- The third is an array with your variables.

**The function have now 3 argument**

function(**$row**,**$alias**,**$array_variables**)

- $row is the result of the query
- $alias is the name of the alias of column before change
- $variable is an array with variable of your script 

