### PR TITLE
feat: uppercase value request->getMethod for CI 4.5

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -20,7 +20,7 @@ class Request
         if($requestName !== NULL)
     	   return $request->getGetPost($requestName);
         
-        return (Object) (($request->getMethod() == 'get') ? $request->getGet() : $request->getPost());
+        return (Object) (($request->getMethod() == 'GET') ? $request->getGet() : $request->getPost());
 
     }
 


### PR DESCRIPTION
In CI 4.5 value of request->getMethod  is not 'get' with lowercase but 'GET' with uppercase