### PR TITLE
Add escape flag to column

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -9,6 +9,6 @@ class Column{
 	public $callback;
 	public $searchable = TRUE;
 	public $orderable = TRUE;
-
+	public $escape = TRUE;
 }
 

--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -126,6 +126,18 @@ class DataTable
         return $this;
     }
 
+    /**
+     * Escape column
+     * 
+     * @param String $column
+     * @param bool $escape
+     */
+    public function escape($column, $escape = TRUE)
+    {
+        $this->columnDefs->escape($column, $escape);
+        return $this;
+    }
+
      /**
      * Set Searchable columns
      * @param String|Array

--- a/src/DataTableColumnDefs.php
+++ b/src/DataTableColumnDefs.php
@@ -33,6 +33,7 @@ class DataTableColumnDefs
         $column->type       = 'numbering';
         $column->searchable = FALSE;
         $column->orderable  = FALSE;
+        $column->escape     = FALSE;
 
         array_unshift($this->columns, $column);
 
@@ -48,6 +49,7 @@ class DataTableColumnDefs
         $column->searchable = FALSE;
         $column->orderable  = FALSE;
         $column->callback   = $callback;
+        $column->escape     = FALSE;
 
         switch ($position) {
            
@@ -95,6 +97,20 @@ class DataTableColumnDefs
             
         }
         
+    }
+
+    public function excludeEscape($alias)
+    {
+        if($alias)
+        {
+            $column = $this->getColumnBy('alias', $alias);
+            if(is_object($column))
+            {
+                $column->escape = TRUE;
+            }
+            
+        }
+
     }
 
     public function remove($alias)

--- a/src/DataTableColumnDefs.php
+++ b/src/DataTableColumnDefs.php
@@ -99,14 +99,14 @@ class DataTableColumnDefs
         
     }
 
-    public function excludeEscape($alias)
+    public function escape($alias, $escape = TRUE)
     {
         if($alias)
         {
             $column = $this->getColumnBy('alias', $alias);
             if(is_object($column))
             {
-                $column->escape = TRUE;
+                $column->escape = $escape;
             }
             
         }

--- a/src/DataTableQuery.php
+++ b/src/DataTableQuery.php
@@ -72,15 +72,13 @@ class DataTableQuery
 
         foreach ($queryResult as $row) 
         {
-            //escaping all
-            foreach($row as $key => $val)
-                $row->$key = esc($val);
-
             $data    = [];
             $columns = $this->columnDefs->getColumns();
 
             foreach ($columns as $index => $column) 
             {
+                if($column->escape)
+                    $row->{$column->alias} = esc($row->{$column->alias});
                 switch ($column->type) {
                     case 'numbering':
                         $value = $this->columnDefs->getNumbering();


### PR DESCRIPTION
FIX hermawanramadhan/CodeIgniter4-DataTables#50

By default all column value will be escaped using `esc` from CI4 common funtion, now it can be excluded. 

**Usage**
```php
use \Hermawan\DataTables\DataTable;
use \App\Models\CustomerModel;

public function ajaxDatatable()
{
    $customerModel = new CustomerModel();
    $customerModel->select('customerNumber, customerName, phone, city, country, postalCode, excludeEscape');

    return DataTable::of($customerModel)->escape('excludeEscape', FALSE)->toJson();
}
```